### PR TITLE
feat: Create Dockerfile and publishing workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*       text=auto
+*.sh    text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        id: docker-build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Build and Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to build
+          images: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/yamllint
+          # generate Docker tags: X.Y.Z, X.Y, X, latest
+          # Note: "latest" is automatically included with type=semver
+          tags: |
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker-build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.docker-build.outputs.digest }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+.idea
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-alpine3.19
+
+# Note: Labels are applied automatically by the CI/CD pipeline
+
+RUN addgroup -g 1000 yamllint && \
+    adduser -u 1000 -G yamllint -s /bin/sh -D yamllint
+RUN pip3 install --root-user-action=ignore --no-cache-dir --no-compile "yamllint==v1.35.1"
+
+WORKDIR /data
+ENTRYPOINT ["yamllint"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # docker-yamllint
-yamllint packaged as a container image, published by Contane
+
+[yamllint](https://github.com/adrienverge/yamllint) packaged as a container
+image, published by [Contane](https://contane.net).
+
+## Usage
+
+The image is Alpine-based. By default, it runs in the `/data` directory with
+the root user. A non-root user named `yamllint` is also available and should
+be used if possible.
+
+See the [yamllint documentation](https://yamllint.readthedocs.io/en/stable/configuration.html)
+for available configuration options that can be set in a `.yamllint.yaml` or
+`.yamllint.yml` file in the working directory.
+
+### Command Line
+
+To run `yamllint` on the current directory:
+
+```sh
+docker run --rm --user yamllint -v $(pwd):/data contane/yamllint -f colored .
+```
+
+### GitLab CI
+
+To use this image in a GitLab CI pipeline, add the following to your `.gitlab-ci.yml`:
+
+```yaml
+yamllint:
+  stage: test
+  image:
+    name: contane/yamllint
+    entrypoint: ["/bin/ash", "-c"]
+    docker:
+      user: yamllint
+  script:
+    - yamllint -f colored .
+```

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,24 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": ["Dockerfile"],
+      "extends": [":semanticCommitTypeAll(fix)"]
+    },
+    {
+      "matchFileNames": ["Dockerfile"],
+      "matchUpdateTypes": ["major", "minor"],
+      "extends": [":semanticCommitTypeAll(feat)"]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["Dockerfile$"],
+      "matchStrings": ["RUN pip3 install .*?\"yamllint==(?<currentValue>.*)\"\\s"],
+      "depNameTemplate": "adrienverge/yamllint",
+      "datasourceTemplate": "github-tags"
+    }
   ]
 }


### PR DESCRIPTION
This patch adds the Dockerfile for the `contane/yamllint` Docker image. Dependencies are kept up-to-date via Renovate. release-please is used to create release proposal PRs when pushing/merging to main. Once a proposal is itself merged, release-please creates a GitHub release. Then, the publish workflow builds and pushes a tagged image to Docker Hub.