### PR TITLE
chore: Fix Renovate semantic commit types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,16 @@
   "packageRules": [
     {
       "matchFileNames": ["Dockerfile"],
-      "extends": [":semanticCommitTypeAll(fix)"]
+      "semanticCommitType": "fix"
     },
     {
       "matchFileNames": ["Dockerfile"],
       "matchUpdateTypes": ["major", "minor"],
-      "extends": [":semanticCommitTypeAll(feat)"]
+      "semanticCommitType": "feat"
+    },
+    {
+      "matchFileNames": [".github/workflows/*.yml"],
+      "semanticCommitType": "chore"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
We need to use semanticCommitType directly instead of via `extends`. Additionally, add a section for GitHub Actions workflows such that PRs like #9 always use "chore" (#9 was originally created with "feat", which is wrong).