### PR TITLE
chore: Publish README to Docker Hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  publish:
     name: Build and Publish
     runs-on: ubuntu-latest
     steps:
@@ -52,3 +52,13 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker-build.outputs.digest }}
+
+      # See: https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/
+      - name: Update DockerHub description
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
+        with:
+          username: contane
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: contane/foreman
+          short-description: ${{ github.event.repository.description }}
+          enable-url-completion: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [yamllint](https://github.com/adrienverge/yamllint) packaged as a container
 image, published by [Contane](https://contane.net).
 
+- Docker Hub: https://hub.docker.com/r/contane/yamllint
+- GitHub: https://github.com/contane/docker-yamllint
+
 ## Usage
 
 The image is Alpine-based. By default, it runs in the `/data` directory with


### PR DESCRIPTION
This ensures that the project description on Docker Hub is always synced with README.md when a release is made.

README.md is updated to include links to GitHub and Docker Hub such that people viewing the project on either platform know where to go for the source code and/or image.