### PR TITLE
docs: Quote variable in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ for available configuration options that can be set in a `.yamllint.yaml` or
 To run `yamllint` on the current directory:
 
 ```sh
-docker run --rm --user yamllint -v $(pwd):/data contane/yamllint -f colored .
+docker run --rm --user yamllint -v "$(pwd):/data" contane/yamllint -f colored .
 ```
 
 ### GitLab CI


### PR DESCRIPTION
If the current working directory path contains a space, the unquoted command would fail.