### PR TITLE
chore: Use proper repository in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,6 @@ jobs:
         with:
           username: contane
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: contane/foreman
+          repository: contane/yamllint
           short-description: ${{ github.event.repository.description }}
           enable-url-completion: true


### PR DESCRIPTION
The README was previously deployed to the wrong repository due to a copy-paste error.