### PR TITLE
feat: Provide a native arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./
+          platforms: linux/amd64,linux/arm64
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ image, published by [Contane](https://contane.net).
 
 The image is Alpine-based. By default, it runs in the `/data` directory with
 the root user. A non-root user named `yamllint` is also available and should
-be used if possible.
+be used if possible. We build for `linux/amd64` and `linux/arm64` platforms.
 
 See the [yamllint documentation](https://yamllint.readthedocs.io/en/stable/configuration.html)
 for available configuration options that can be set in a `.yamllint.yaml` or


### PR DESCRIPTION
With arm-based CPUs becoming more relevant both for consumers and in the datacenter, providing a native build for arm64 likely adds significant value to this image.