### PR TITLE
docs: Add example for GitHub Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Default ignored files
+.DS_Store
 .idea
+.vscode
 .env

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ To run `yamllint` on the current directory:
 docker run --rm --user yamllint -v "$(pwd):/data" contane/yamllint -f colored .
 ```
 
+### GitHub Actions
+
+To use this image in a GitHub Actions workflow, add the following to your `.github/workflows/*.yml`:
+
+```yaml
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    container:
+      image: contane/yamllint
+    steps:
+      - uses: actions/checkout@v4
+      - run: yamllint -f colored .
+```
+
 ### GitLab CI
 
 To use this image in a GitLab CI pipeline, add the following to your `.gitlab-ci.yml`:


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container

I tested this on a private demo repository and it worked great. The only limitation is that a non-root user cannot be specified as it breaks the checkout action.