### PR TITLE
chore: Configure Renovate to group GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
     {
       "matchFileNames": [".github/workflows/*.yml"],
       "semanticCommitType": "chore"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "groupName": "actions"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
This is intended to reduce the number of individual PRs, as GitHub Actions updates are a large part of the overall Renovate PRs.